### PR TITLE
Added kotlinx.serialization and setup server

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,8 @@ kotlin {
             implementation(libs.koin.androidx.compose)
         }
         commonMain.dependencies {
+            implementation(projects.shared)
+
             implementation(libs.kotlinx.coroutines.core)
             implementation(compose.runtime)
             implementation(compose.foundation)
@@ -77,7 +79,7 @@ kotlin {
             implementation(libs.voyager.koin)
             implementation(libs.gson)
             implementation(libs.arrow.core)
-            implementation(projects.shared)
+
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ navigation = "2.9.1"
 composeMultiplatform = "1.8.2"
 junit = "4.13.2"
 kotlin = "2.2.0"
+kotlinx-serialization = "1.9.0"
 coroutines = "1.10.2"
 ktor = "3.2.1"
 voyager = "1.1.0-beta03"
@@ -23,9 +24,12 @@ arrow = "2.1.2"
 logback = "1.5.18"
 
 [libraries]
+# Kotlin
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+
+# Android
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
@@ -66,14 +70,15 @@ ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "k
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktor-serialization-gson = { module = "io.ktor:ktor-serialization-gson", version.ref = "ktor" }
-
-# Ktor server
-logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
 ktor-serverTestHost = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.ktor)
     application
+    kotlin("plugin.serialization") version libs.versions.kotlin.get()
 }
 
 group = "com.eugenerogov.planmind"
@@ -14,11 +15,20 @@ application {
 }
 
 dependencies {
-    implementation(libs.arrow.core)
     implementation(projects.shared)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+
+    implementation(libs.koin.core)
+    implementation(libs.arrow.core)
+
     implementation(libs.logback)
     implementation(libs.ktor.serverCore)
     implementation(libs.ktor.serverNetty)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    
     testImplementation(libs.ktor.serverTestHost)
     testImplementation(libs.kotlin.testJunit)
 }

--- a/server/src/main/kotlin/com/eugenerogov/planmind/Application.kt
+++ b/server/src/main/kotlin/com/eugenerogov/planmind/Application.kt
@@ -1,10 +1,13 @@
 package com.eugenerogov.planmind
 
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import kotlinx.serialization.json.Json
 
 fun main() {
     embeddedServer(Netty, port = SERVER_PORT, host = "0.0.0.0", module = Application::module)
@@ -13,8 +16,22 @@ fun main() {
 
 fun Application.module() {
     routing {
+        install(ContentNegotiation) {
+            json(Json {
+                prettyPrint = true
+                isLenient = true
+                ignoreUnknownKeys = true
+            })
+        }
+
         get("/") {
             call.respondText("Ktor: ${Greeting().greet()}")
         }
+
+        get("/plan-mind") {
+            val data = mapOf("names" to listOf("Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Helen", "Isaac", "Julia"))
+            call.respond(data)
+        }
     }
 }
+

--- a/server/src/main/kotlin/com/eugenerogov/planmind/di/UseCaseModule.kt
+++ b/server/src/main/kotlin/com/eugenerogov/planmind/di/UseCaseModule.kt
@@ -1,0 +1,22 @@
+package com.eugenerogov.planmind.di
+
+import com.eugenerogov.planmind.domain.usecases.SignInLoginUseCase
+import kotlinx.coroutines.Dispatchers
+import org.koin.dsl.module
+
+val useCasesModule =
+    module {
+        // region Task
+
+        // endregion
+
+        // region Auth
+        factory {
+            SignInLoginUseCase(
+//                repository = get(),
+                dispatcher = Dispatchers.Default
+            )
+        }
+        // endregion
+
+    }


### PR DESCRIPTION
This commit introduces the following changes:
- Added kotlinx.serialization as a dependency in `gradle/libs.versions.toml`.
- Configured the Ktor server in `server/src/main/kotlin/com/eugenerogov/planmind/Application.kt` to use JSON content negotiation with kotlinx.serialization.
- Added a new endpoint `/plan-mind` to the server which returns a list of names as JSON.
- Added a new `UseCaseModule.kt` in `server/src/main/kotlin/com/eugenerogov/planmind/di/` for Koin dependency injection, specifically for a `SignInLoginUseCase`.
- Updated dependencies in `server/build.gradle.kts` to include Koin, Arrow Core, coroutines, and serialization.
- Moved `projects.shared` dependency from `commonMain` to the top-level dependencies in `composeApp/build.gradle.kts`.